### PR TITLE
Add example showcasing `f2py` usage via CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,17 @@
 # Apple Desktop Services Store
 **.DS_Store
+# CMake related build files
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/numpy-examples/CMakeLists.txt
+++ b/numpy-examples/CMakeLists.txt
@@ -1,0 +1,68 @@
+# based off docs template: https://numpy.org/doc/stable/f2py/buildtools/cmake.html#using-via-cmake
+cmake_minimum_required(VERSION 3.18) # Needed to avoid requiring embedded Python libs too
+
+project(fibonacci
+  VERSION 1.0
+  DESCRIPTION "FIB module"
+  LANGUAGES C Fortran
+)
+
+# Safety net
+if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  message(
+    FATAL_ERROR
+      "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there.\n"
+  )
+endif()
+
+# Look for the nearest python installation in a conda/virtualenv
+# https://cmake.org/cmake/help/latest/module/FindPython.html
+set(Python_FIND_VIRTUALENV ONLY)
+find_package(Python 3.12 REQUIRED
+  COMPONENTS Interpreter Development.Module NumPy)
+
+# Grab the variables from a local Python installation
+# F2PY headers
+execute_process(
+  COMMAND "${Python_EXECUTABLE}"
+  -c "import numpy.f2py; print(numpy.f2py.get_include())"
+  OUTPUT_VARIABLE F2PY_INCLUDE_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Print out the discovered paths
+include(CMakePrintHelpers)
+cmake_print_variables(Python_INCLUDE_DIRS)
+cmake_print_variables(F2PY_INCLUDE_DIR)
+cmake_print_variables(Python_NumPy_INCLUDE_DIRS)
+
+# Common variables
+set(f2py_module_name "fibonacci")
+set(fortran_src_file "${CMAKE_SOURCE_DIR}/fibonacci.f")
+set(f2py_module_c "${f2py_module_name}module.c")
+
+# Generate sources
+add_custom_target(
+  genpyf
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${f2py_module_c}"
+)
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${f2py_module_c}"
+  COMMAND ${Python_EXECUTABLE}  -m "numpy.f2py"
+                   "${fortran_src_file}"
+                   -m "fibonacci"
+                   --lower # Important
+  DEPENDS fibonacci.f # Fortran source
+)
+
+# Set up target
+Python_add_library(${CMAKE_PROJECT_NAME} MODULE WITH_SOABI
+  "${CMAKE_CURRENT_BINARY_DIR}/${f2py_module_c}" # Generated
+  "${F2PY_INCLUDE_DIR}/fortranobject.c" # From NumPy
+  "${fortran_src_file}" # Fortran source(s)
+)
+
+# Depend on sources
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Python::NumPy)
+add_dependencies(${CMAKE_PROJECT_NAME} genpyf)
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE "${F2PY_INCLUDE_DIR}")

--- a/numpy-examples/README.md
+++ b/numpy-examples/README.md
@@ -32,3 +32,14 @@ After removing `depend(m,n)` statement from the signature file (see [here](https
 python -m numpy.f2py -c myroutine.pyf myroutine.f90
 ```
 Test the module can be correctly imported via `python myrout.py`.
+
+## CMake example 
+
+Example using CMake to build (see [here](https://numpy.org/doc/stable/f2py/buildtools/cmake.html#using-via-cmake) for details) Fibonacci sequence in Fortran 77 ([fibonacci.f](./fibonacci.f)):
+```shell
+cmake -S . -B build
+cmake --build build
+cd build
+python -c "import fibonacci; print(fibonacci.fib.__doc__);print('Fibonacci sequence for 15');print(fibonacci.fib(10))";
+```
+

--- a/numpy-examples/fibonacci.f
+++ b/numpy-examples/fibonacci.f
@@ -1,0 +1,21 @@
+C FILE: FIB3.F
+      SUBROUTINE FIB(A,N)
+C
+C     CALCULATE FIRST N FIBONACCI NUMBERS
+C
+      INTEGER N
+      REAL*8 A(N)
+Cf2py intent(in) n
+Cf2py intent(out) a
+Cf2py depend(n) a
+      DO I=1,N
+         IF (I.EQ.1) THEN
+            A(I) = 0.0D0
+         ELSEIF (I.EQ.2) THEN
+            A(I) = 1.0D0
+         ELSE 
+            A(I) = A(I-1) + A(I-2)
+         ENDIF
+      ENDDO
+      END
+C END FILE FIB3.F


### PR DESCRIPTION
Adds a simple example `fibonacci.f` containing a Fortran 77 implementation of the Fibonacci Algorithm and also showcasing f2py directives usage. Provides an example of CMake usage to build using `f2py`.